### PR TITLE
Basic認証

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,13 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])


### PR DESCRIPTION
# What
アプリケーションにBasic認証を導入するため。
# Why
サーバーとの通信が可能なユーザーとパスワードをあらかじめ設定し、それに一致したユーザーのみにアプリケーション利用を制限するため。